### PR TITLE
Partial fix vulkan-go/vulkan#19, add IOSurface to darwin LDFLAGS

### DIFF
--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -16,7 +16,7 @@ package glfw
 #cgo darwin CFLAGS: -D_GLFW_COCOA -D_GLFW_VULKAN_STATIC -D_GLFW_USE_CHDIR -D_GLFW_USE_MENUBAR -D_GLFW_USE_RETINA -Wno-deprecated-declarations
 
 // Linker Options:
-#cgo darwin LDFLAGS: -framework Cocoa -framework OpenGL -framework IOKit -framework QuartzCore -framework Metal -framework MoltenVK -lc++
+#cgo darwin LDFLAGS: -framework Cocoa -framework OpenGL -framework IOKit -framework IOSurface -framework QuartzCore -framework Metal -framework MoltenVK -lc++
 
 
 // Linux Build Tags


### PR DESCRIPTION
This PR adds the `-framework IOSurface` linker flag required for current MoltenVK versions. Together with vulkan-go/vulkan#20 these two changes fixed the issue for me